### PR TITLE
[FIX] Title post doesn’t displayed in welcome topic

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -143,7 +143,7 @@ class listener implements EventSubscriberInterface
 		'force_approved_state'    => true, // Allow the post to be submitted without going into unapproved queue
 		);
 		
-		submit_post('post', 'topic_title', 'robot_name', POST_NORMAL, $poll, $data);
+		submit_post('post', $topic_title, 'robot_name', POST_NORMAL, $poll, $data);
 		
 		return true;
 	}


### PR DESCRIPTION
Hi,

when a new registered user login at the first time, the welcome topic doesn’t have the good title topic.